### PR TITLE
allow failures on ubuntu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,11 @@ env:
   - PLATFORM=arch
   - PLATFORM=opensuse
 
+matrix:
+  allow_failures:
+  - env: PLATFORM=ubuntu-1804
+  - env: PLATFORM=ubuntu-1604
+
 sudo: true
 dist: trusty
 


### PR DESCRIPTION
1604 and 1804 will timeout because apt is the slowest package manager